### PR TITLE
improving/ search-client-screen

### DIFF
--- a/app/src/main/java/com/rodcollab/cliq/collections/bookings/form/SearchClientFragment.kt
+++ b/app/src/main/java/com/rodcollab/cliq/collections/bookings/form/SearchClientFragment.kt
@@ -90,13 +90,20 @@ class SearchClientFragment : Fragment() {
     }
 
     private fun updateListAccordingToOnQueryChanged() {
+
+        viewModel.getLastClient()
+            .observe(viewLifecycleOwner) {
+                binding.searchViewClients.setQuery(it, false)
+            }
+
+
         binding.searchViewClients.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
-
                 return false
             }
 
             override fun onQueryTextChange(newText: String?): Boolean {
+
 
                 viewModel.onQueryTextChange(newText.toString())
                 viewModel.stateOnceAndStream().observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/rodcollab/cliq/collections/bookings/form/SearchClientViewModel.kt
+++ b/app/src/main/java/com/rodcollab/cliq/collections/bookings/form/SearchClientViewModel.kt
@@ -19,6 +19,18 @@ class SearchClientViewModel(
         MutableLiveData<ClientSelectedState>()
     }
 
+    private val lastClient: MutableLiveData<String> by lazy {
+        MutableLiveData<String>()
+    }
+
+    fun getLastClient() : LiveData<String>  {
+        viewModelScope.launch {
+            lastClient.value = getClientsUseCase().last().name
+
+        }
+        return lastClient
+    }
+
     data class ClientSelectedState(
         val wasSelected: Boolean,
         val clientSelected: ClientItem?


### PR DESCRIPTION
## What's this PR doing?

* when the user adds a new client and navigates to the search clients screen, they should be able to retrieve the last client that was added.